### PR TITLE
Adapted code to work with revised filenames. Will need refactoring.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: NHS England publishes monthly aggregated data on A&E attendance num
 License: file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0
 Suggests: testthat
 Imports: dplyr (>= 0.7.4),
     stringr (>= 1.3.0),

--- a/R/scrape_AE_data_Eng.R
+++ b/R/scrape_AE_data_Eng.R
@@ -120,7 +120,7 @@ getAEdata_page_urls_monthly <- function(index_url, country = "England") {
 
            #Look for lines that contain the signature part of the url and the signature text
            data_url_lines <- grep("^(?=.*xls)((?!Quarter).)*$",html_lines, perl=TRUE)
-           xlsdata_url_lines <- grep("by-provider",html_lines[data_url_lines])
+           xlsdata_url_lines <- grep("AE",html_lines[data_url_lines])
            NHSE_xlsdata_lines <- html_lines[data_url_lines][xlsdata_url_lines]
 
            #Extract urls from html lines
@@ -137,7 +137,9 @@ getAEdata_page_urls_monthly <- function(index_url, country = "England") {
            #to remove duplicates of files ending in xlsx
            urls <- urls[!urls_xlsx_selection]
 
-           urls <- c(urls, urls_xlsx)
+           urls <- c(urls, urls_xlsx,
+                     "https://www.england.nhs.uk/statistics/wp-content/uploads/sites/2/2020/08/Monthly-October-2019-revised-210720-qm5hG.xls",
+                     "https://www.england.nhs.uk/statistics/wp-content/uploads/sites/2/2020/08/Monthly-September-2019-revised-210720-L48uy.xls")
 
          },
          "Scotland" = {
@@ -217,9 +219,12 @@ load_AE_files <- function(directory = file.path('data-raw','sitreps'),
 
   switch(country,
          "England" = {
-           fileNames <- Sys.glob(file.path(directory,'*by-provider*.xls'))
-           fileNames_xlsx <- Sys.glob(file.path(directory,'*by-provider*.xlsx'))
-           fileNames <- c(fileNames, fileNames_xlsx)
+           fileNames <- Sys.glob(file.path(directory,'*AE*.xls'))
+           fileNames_xlsx <- Sys.glob(file.path(directory,'*AE*.xlsx'))
+           fileNames_extras <- c(Sys.glob(file.path(directory,"Monthly-October-2019-revised-210720-qm5hG.xls")),
+                                 Sys.glob(file.path(directory,"Monthly-September-2019-revised-210720-L48uy.xls")))
+           fileNames <- c(fileNames, fileNames_xlsx, fileNames_extras)
+           fileNames <- fileNames[-grep("Adjusted",fileNames)]
          },
          "Scotland" = {
            fileNames <- Sys.glob(file.path(directory,'*-data*.csv'))

--- a/man/getAE_data.Rd
+++ b/man/getAE_data.Rd
@@ -4,9 +4,13 @@
 \alias{getAE_data}
 \title{getAE_data}
 \usage{
-getAE_data(update_data = TRUE, directory = file.path("data-raw",
-  "sitreps"), url_list = NULL, use_filename_date = FALSE,
-  country = "England")
+getAE_data(
+  update_data = TRUE,
+  directory = file.path("data-raw", "sitreps"),
+  url_list = NULL,
+  use_filename_date = FALSE,
+  country = "England"
+)
 }
 \arguments{
 \item{update_data}{whether to download files afresh from NHS England/Scotland website (TRUE)

--- a/man/load_AE_files.Rd
+++ b/man/load_AE_files.Rd
@@ -4,8 +4,11 @@
 \alias{load_AE_files}
 \title{load_AE_files}
 \usage{
-load_AE_files(directory = file.path("data-raw", "sitreps"),
-  use_filename_date = TRUE, country = "England")
+load_AE_files(
+  directory = file.path("data-raw", "sitreps"),
+  use_filename_date = TRUE,
+  country = "England"
+)
 }
 \arguments{
 \item{directory}{path of the directory to load files from}


### PR DESCRIPTION
This is a quick fix for the current issue that the app is facing where the data from April 2019 - March 2020 and July 2020 is missing from the graphs.  The problem is that these files were all revised on 13/08/20 by NHS England and renamed without following the convention or any consistent convention really.  I have therefore had to paste in a couple of file URLs which weren't named in the right way. 

This issue should hopefully go away when we switch to cloud storage so I think this quick fix is okay for now!